### PR TITLE
correction on documentation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Attributes
  * `node["confluent"]["kafka"]["log4j.properties"]` : A Hash of properties that configure log4j for the Kafka service (see attributes for defaults)
  * `node['confluent']['kafka']['brokers']` : A single broker String or List of brokers by hostname, fqdn, or ipaddress
  * `node['confluent']['kafka']['zookeepers']` : A list of zookeeper hostname:port's to add to kafka config (default=`nil`)
- * `node['confluent']['kafka']['zookeepers_chroot']` : An optional list of zookeeper hostname:port/chroot's to add to kafka config (default=`nil`)
+ * `node['confluent']['kafka']['zookeeper_chroot']` : An optional chroot path for zookeeper hostname:port/chroot's to add to kafka config (default=`nil`)
 
 ### Kafka REST
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,6 +11,7 @@ default["confluent"]["group"] = "confluent"
 
 default["confluent"]["kafka"]["server.properties"] = {}
 default['confluent']['kafka']['zookeepers'] = nil
+default['confluent']['kafka']['zookeeper_chroot'] = nil
 default['confluent']['kafka']['brokers'] = nil
 default["confluent"]["kafka"]["env_vars"] = {}
 default["confluent"]["kafka"]["class"] = "kafka.Kafka"


### PR DESCRIPTION
the zookeeper_chroot attribute is name with "zookeepers_chroot" but in recipe it's "zookeeper_chroot" without "s".